### PR TITLE
Shorter syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,32 +9,19 @@ But, what if we had a simple model creating library that would lock down objects
 
 ```
 const Todo = Typesafe.defineClass({
-  properties: [
-    {
-      name: 'author',
-      type: 'object',
-      properties: [
-        {
-          name: 'name',
-          type: 'object',
-          properties: [
-            {
-              name: 'first',
-              type: 'string'
-            },
-            {
-              name: 'last',
-              type: 'string'
-            }
-          ]
-        },
-        {
-          name: 'age',
-          type: 'number'
+  properties: {
+    author: {
+      properties: {
+        name: {
+          properties: {
+            first: String,
+            last: String
+          }
         }
-      ]
-    }
-  ]
+      }
+    },
+    age: Number
+  }
 });
 ```
 
@@ -43,12 +30,9 @@ const Todo = Typesafe.defineClass({
 Typesafe throws an exception if you try to assign a value to a property that has been defined as a different type. For example:
 ```
   const Todo = Typesafe.defineClass({
-    properties: [
-      {
-        name: 'message',
-        type: 'string'
-      }
-    ]
+    properties: {
+      message: String
+    }
   });
   let instance = new Todo();
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 Typesafe javascript classes
 
 ## why type safety?
-
 Javascript is great. It's great for speedy development and minimal overhead for a project. But what it gains in efficiency, it sacrifices in developer sleep. There will be a few error messages below that you'll probably remember seeing; Most likely when Pagerduty was so kind to send you a phone call and text late at night.
 
 But, what if we had a simple model creating library that would lock down objects and make their structure both immutable and type safe? We could essentially define a model like this:
@@ -26,7 +25,6 @@ const Todo = Typesafe.defineClass({
 ```
 
 ### Error: cannot call property X on type Y
-
 Typesafe throws an exception if you try to assign a value to a property that has been defined as a different type. For example:
 ```
   const Todo = Typesafe.defineClass({
@@ -45,3 +43,4 @@ Typesafe throws an exception if you try to assign a value to a property that has
 This strategy depends on things like testing your app or code before shipping; especially when dealing with 3rd party APIs. This works since obviously a test would fail when trying to use a String like a Number.
 
 ### Error: cannot read property X of undefined?
+*** Implement `getp` function

--- a/src/index.js
+++ b/src/index.js
@@ -3,57 +3,82 @@ module.exports = {
   defineClass: function defineClass(defn) {
     return function classDefn() {
       var instance = {};
-      var properties = defn.properties || [];
+      var properties = Object.keys(defn.properties || []);
+      var propName;
+      var propConfig;
 
       for(var i = 0; i < properties.length; i++) {
-        if (properties[i].type === 'object') {
-          _defineObjectProp(instance, properties[i]);
-        } else {
-          _defineProp(instance, properties[i]);
+        propName = properties[i];
+        propConfig = defn.properties[propName];
+
+        if (typeof defn.properties[propName] !== 'object') {
+          _defineProp(instance, propName, propConfig);
+        }
+        if (typeof defn.properties[propName] === 'object') {
+          _defineObjectProp(instance, propName, propConfig);
         }
       }
 
       return Object.preventExtensions(instance);
     };
 
-    function _defineProp(instance, propConfig) {
-      var shadowVal;
+    function _determineType(prop) {
+      if (prop === String) {
+        return 'string';
+      }
+      if (prop === Number) {
+        return 'number';
+      }
+      if (prop === Boolean) {
+        return 'boolean';
+      }
+    }
 
-      Object.defineProperty(instance, propConfig.name, {
+    function _defineProp(instance, name, config) {
+      var shadowVal;
+      var _type = _determineType(config);
+
+      Object.defineProperty(instance, name, {
         configurable: false, 
         enumerable: true, 
         get: function() {
           return shadowVal;
         },
         set: function(value) {
-          if (typeof value === typeof propConfig.type) {
+          if (typeof value === _type) {
             shadowVal = value;
           } else {
             throw new Error(
-              'Cannot set property ' + propConfig.name + ' ' +
+              'Cannot set property ' + name + ' ' +
               'with a value of type ' + typeof value + '. ' + 
-              'It is defined as type ' + typeof propConfig.type
+              'It is defined as type ' + _type
             );
           }
         }
       });
     }
 
-    function _defineObjectProp(instance, propConfig) {
+    function _defineObjectProp(instance, name, config) {
       var obj = {};
-      var properties = propConfig.properties || [];
+      var properties = Object.keys(config.properties || []);
+      var propName;
+      var propConfig;
 
       for(var i = 0; i < properties.length; i++) {
-        if (properties[i].type === 'object') {
-          _defineObjectProp(obj, properties[i]);
-        } else {
-          _defineProp(obj, properties[i]);
+        propName = properties[i];
+        propConfig = config.properties[propName];
+
+        if (typeof config.properties[propName] !== 'object') {
+          _defineProp(obj, propName, propConfig);
+        }
+        if (typeof config.properties[propName] === 'object') {
+          _defineObjectProp(obj, propName, propConfig);
         }
       }
 
       Object.preventExtensions(obj);
 
-      instance[propConfig.name] = obj;
+      instance[name] = obj;
     }
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -28,12 +28,9 @@ describe('Defining a class', () => {
 
     it('should add properties on the instance', () => {
       const Todo = Typesafe.defineClass({
-        properties: [
-          {
-            name: 'message',
-            type: 'string'
-          }
-        ]
+        properties: {
+          message: String
+        }
       });
       let instance = new Todo();
 
@@ -48,15 +45,11 @@ describe('Defining a class', () => {
 
     it('throws exception. Wont update property if value type is different than definition type', (done) => {
       const Todo = Typesafe.defineClass({
-        properties: [
-          {
-            name: 'message',
-            type: 'string'
-          }
-        ]
+        properties: {
+          message: String
+        }
       });
       let instance = new Todo();
-
       instance.message = 'should be added';
 
       try {
@@ -67,24 +60,59 @@ describe('Defining a class', () => {
       }
     });
 
+    describe('Supported Primitive Types', () => {
+      
+      it('supports String', () => {
+        const Todo = Typesafe.defineClass({
+          properties: {
+            message: String
+          }
+        });
+        let instance = new Todo();
+        instance.message = 'should be added';
+
+        expect(instance.message).to.equal('should be added');
+      });
+
+      it('supports Number', () => {
+        const Todo = Typesafe.defineClass({
+          properties: {
+            count: Number
+          }
+        });
+        let instance = new Todo();
+        instance.count = 33;
+
+        expect(instance.count).to.equal(33);
+      });
+
+      it('supports Boolean', () => {
+        const Todo = Typesafe.defineClass({
+          properties: {
+            done: Boolean
+          }
+        });
+        let instance = new Todo();
+        instance.done = true;
+
+        expect(instance.done).to.equal(true);
+      });
+
+    });
+
   });
 
   describe('Adding basic object properties', () => {
 
     it('creates an object property on the instance', () => {
       const Todo = Typesafe.defineClass({
-        properties: [
-          {
-            name: 'author',
-            type: 'object',
-            properties: [
-              {
-                name: 'firstName',
-                type: 'string'
-              }
-            ]
+        properties: {
+          author: {
+            properties: {
+              firstName: String
+            }
           }
-        ]
+        }
       });
       let instance = new Todo();
 
@@ -97,18 +125,13 @@ describe('Defining a class', () => {
 
     it('seals object property to prevent adding new properties', (done) => {
       const Todo = Typesafe.defineClass({
-        properties: [
-          {
-            name: 'author',
-            type: 'object',
-            properties: [
-              {
-                name: 'firstName',
-                type: 'string'
-              }
-            ]
+        properties: {
+          author: {
+            properties: {
+              firstName: String
+            }
           }
-        ]
+        }
       });
       let instance = new Todo();
 
@@ -124,18 +147,13 @@ describe('Defining a class', () => {
 
     it('throws exception. Wont update sub property if value type is different than definition type', (done) => {
       const Todo = Typesafe.defineClass({
-        properties: [
-          {
-            name: 'author',
-            type: 'object',
-            properties: [
-              {
-                name: 'firstName',
-                type: 'string'
-              }
-            ]
+        properties: {
+          author: {
+            properties: {
+              firstName: String
+            }
           }
-        ]
+        }
       });
       let instance = new Todo();
 
@@ -143,7 +161,6 @@ describe('Defining a class', () => {
         instance.author.firstName = 47;
 
         expect(Object.keys(instance.author).length).to.equal(1);
-        expect(instance.author.lastName).to.equal(undefined);
 
         done(new Error('should have thrown exception'));
       } catch(e) { done(); }
@@ -151,32 +168,19 @@ describe('Defining a class', () => {
 
     it('recurses through object property children', () => {
       const Todo = Typesafe.defineClass({
-        properties: [
-          {
-            name: 'author',
-            type: 'object',
-            properties: [
-              {
-                name: 'name',
-                type: 'object',
-                properties: [
-                  {
-                    name: 'first',
-                    type: 'string'
-                  },
-                  {
-                    name: 'last',
-                    type: 'string'
-                  }
-                ]
+        properties: {
+          author: {
+            properties: {
+              name: {
+                properties: {
+                  first: String,
+                  last: String
+                }
               },
-              {
-                name: 'age',
-                type: 'number'
-              }
-            ]
+              age: Number
+            }
           }
-        ]
+        }
       });
       let instance = new Todo();
 
@@ -192,7 +196,5 @@ describe('Defining a class', () => {
     });
 
   });
-
-  
 
 });


### PR DESCRIPTION
changes syntax from 
```
const Todo = Typesafe.defineClass({
  properties: [
    {
      name: 'author',
      type: 'object',
      properties: [
        {
          name: 'name',
          type: 'object',
          properties: [
            {
              name: 'first',
              type: 'string'
            },
            {
              name: 'last',
              type: 'string'
            }
          ]
        },
        {
          name: 'age',
          type: 'number'
        }
      ]
    }
  ]
});
```
to
```
const Todo = Typesafe.defineClass({
  properties: {
    author: {
      properties: {
        name: {
          properties: {
            first: String,
            last: String
          }
        }
      }
    },
    age: Number
  }
});
```